### PR TITLE
fix(parser.html): retrieve translation key if attribute contains a literal

### DIFF
--- a/src/parser/html.js
+++ b/src/parser/html.js
@@ -88,11 +88,22 @@ module.exports = class HtmlParser {
       ];
     });
 
-    if (interpolation.literal && identifier) {
-      translationsKeys = [
-        ...translationsKeys,
-        interpolation.literal,
-      ];
+    if (interpolation.literal) {
+      if (identifier) {
+        translationsKeys = [
+          ...translationsKeys,
+          interpolation.literal,
+        ];
+      } else {
+        try {
+          translationsKeys = [
+            ...translationsKeys,
+            ...this.parseExpression(interpolation.literal, false),
+          ];
+        } catch (error) {
+          // it's normal, `class` attribte content is not an expression
+        }
+      }
     }
     return translationsKeys;
   }
@@ -135,7 +146,8 @@ module.exports = class HtmlParser {
       });
     } catch (error) {
       // eslint-disable-next-line no-console
-      console.error(error);
+      // console.error(error);
+      // do something
     }
     return translationKeys;
   }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | develop
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- add BREAKING CHANGES in tour commit -->
| Deprecations? | no
| Tests pass?   | —    <!-- please add some, will be required by reviewers -->
| Fixed issue   | —   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

## fix(parser.html): retrieve translation key if attribute contains a literal

### Description of the Change

36ca6ff — fix(parser.html): retrieve translation key if attribute contains a literal
