### PR TITLE
fix(simonsays.rewrite): avoid generating empty translations files

### DIFF
--- a/src/simonsays.js
+++ b/src/simonsays.js
@@ -108,6 +108,7 @@ module.exports = class SimonSays {
     prefix = '',
   ) {
     const modules = await this.search(projectPath, byModule, locale, merge, all);
+    const modulesToUpdate = modules.filter(module => Object.keys(module.compatibles).length > 0);
 
     let translationPrefix = '';
     if (prefix !== '') {
@@ -115,7 +116,7 @@ module.exports = class SimonSays {
     }
 
     return Promise.mapSeries(
-      modules,
+      modulesToUpdate,
       async (module) => {
         const moduleRenamed = await SimonSays.renameTranslations(
           module,


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | develop
| Bug fix?      | yes
| New feature?  | no <!-- don't forget to update src/**/CHANGELOG.md files -->
| BC breaks?    | no     <!-- add BREAKING CHANGES in tour commit -->
| Deprecations? | no
| Tests pass?   | —    <!-- please add some, will be required by reviewers -->
| Fixed issue   | —   <!-- #-prefixed issue number(s), if any -->
| License       | MIT

## fix(simonsays.rewrite): avoid generating empty translations files

### Description of the Change

fixes #3

3c2cbfb — fix(simonsays.rewrite): avoid generating empty translations files

